### PR TITLE
Feature/symfony form type range support

### DIFF
--- a/src/Form/Helper/FormHelper.php
+++ b/src/Form/Helper/FormHelper.php
@@ -3,7 +3,6 @@
 namespace Cyve\JsonSchemaFormBundle\Form\Helper;
 
 use Cyve\JsonSchemaFormBundle\Form\Type\SchemaType;
-use stdClass;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
@@ -20,10 +19,10 @@ use Symfony\Component\Form\Extension\Core\Type\UrlType;
 class FormHelper
 {
     /**
-     * @param stdClass $property
+     * @param \stdClass $property
      * @return string|null
      */
-    public static function resolveFormType(stdClass $property): ?string
+    public static function resolveFormType(\stdClass $property): ?string
     {
         if (is_array($property->type)) {
             throw new \LogicException('Multiple types support is not implemeted yet');
@@ -72,10 +71,10 @@ class FormHelper
     }
 
     /**
-     * @param stdClass $property
+     * @param \stdClass $property
      * @return array
      */
-    public static function resolveFormOptions(stdClass $property): array
+    public static function resolveFormOptions(\stdClass $property): array
     {
         if (is_array($property->type)) {
             throw new \LogicException('Multiple types support is not implemeted yet');
@@ -140,10 +139,10 @@ class FormHelper
 
     /**
      * Check if the Property is from type number and has the (exclusive)minimum and (exclusive)maximum attribute
-     * @param stdClass $property
+     * @param \stdClass $property
      * @return bool
      */
-    public static function isRangeType(stdClass $property): bool
+    public static function isRangeType(\stdClass $property): bool
     {
         return 'number' === $property->type &&
             (property_exists($property, 'minimum')

--- a/src/Form/Helper/FormHelper.php
+++ b/src/Form/Helper/FormHelper.php
@@ -3,7 +3,6 @@
 namespace Cyve\JsonSchemaFormBundle\Form\Helper;
 
 use Cyve\JsonSchemaFormBundle\Form\Type\SchemaType;
-use njsosch\Form\Mapper\JsonSchemaPropertyTypeMapper;
 use stdClass;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -21,10 +20,10 @@ use Symfony\Component\Form\Extension\Core\Type\UrlType;
 class FormHelper
 {
     /**
-     * @param object $property
+     * @param stdClass $property
      * @return string|null
      */
-    public static function resolveFormType($property): ?string
+    public static function resolveFormType(stdClass $property): ?string
     {
         if (is_array($property->type)) {
             throw new \LogicException('Multiple types support is not implemeted yet');
@@ -73,10 +72,10 @@ class FormHelper
     }
 
     /**
-     * @param object $property
+     * @param stdClass $property
      * @return array
      */
-    public static function resolveFormOptions($property): array
+    public static function resolveFormOptions(stdClass $property): array
     {
         if (is_array($property->type)) {
             throw new \LogicException('Multiple types support is not implemeted yet');

--- a/src/Form/Helper/FormHelper.php
+++ b/src/Form/Helper/FormHelper.php
@@ -3,6 +3,8 @@
 namespace Cyve\JsonSchemaFormBundle\Form\Helper;
 
 use Cyve\JsonSchemaFormBundle\Form\Type\SchemaType;
+use njsosch\Form\Mapper\JsonSchemaPropertyTypeMapper;
+use stdClass;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
@@ -11,6 +13,7 @@ use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\Extension\Core\Type\RangeType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Extension\Core\Type\TimeType;
 use Symfony\Component\Form\Extension\Core\Type\UrlType;
@@ -18,20 +21,20 @@ use Symfony\Component\Form\Extension\Core\Type\UrlType;
 class FormHelper
 {
     /**
-     * @param object $schema
+     * @param object $property
      * @return string|null
      */
-    public static function resolveFormType($schema): ?string
+    public static function resolveFormType($property): ?string
     {
-        if (is_array($schema->type)) {
+        if (is_array($property->type)) {
             throw new \LogicException('Multiple types support is not implemeted yet');
         }
 
-        if (isset($schema->enum)) {
+        if (isset($property->enum)) {
             return ChoiceType::class;
         }
 
-        switch ($schema->type) {
+        switch ($property->type) {
             case 'array':
                 return CollectionType::class;
             case 'object':
@@ -39,11 +42,14 @@ class FormHelper
             case 'integer':
                 return IntegerType::class;
             case 'number':
+                if (static::isRangeType($property)) {
+                    return RangeType::class;
+                }
                 return NumberType::class;
             case 'boolean':
                 return CheckboxType::class;
             case 'string':
-                switch ($schema->format ?? null) {
+                switch ($property->format ?? null) {
                     case 'date-time':
                         return DateTimeType::class;
                     case 'date':
@@ -67,46 +73,46 @@ class FormHelper
     }
 
     /**
-     * @param object $schema
+     * @param object $property
      * @return array
      */
-    public static function resolveFormOptions($schema): array
+    public static function resolveFormOptions($property): array
     {
-        if (is_array($schema->type)) {
+        if (is_array($property->type)) {
             throw new \LogicException('Multiple types support is not implemeted yet');
         }
 
         $options = [];
 
-        if (isset($schema->title)) {
-            $options['label'] = $schema->title;
+        if (isset($property->title)) {
+            $options['label'] = $property->title;
         }
 
-        if (isset($schema->description)) {
-            $options['help'] = $schema->description;
+        if (isset($property->description)) {
+            $options['help'] = $property->description;
         }
 
-        if (isset($schema->default)) {
-            $options['empty_data'] = $schema->default;
+        if (isset($property->default)) {
+            $options['empty_data'] = $property->default;
         }
 
-        if (isset($schema->enum)) {
-            return $options + ['choices' => array_combine($schema->enum, $schema->enum)];
+        if (isset($property->enum)) {
+            return $options + ['choices' => array_combine($property->enum, $property->enum)];
         }
 
-        switch ($schema->type) {
+        switch ($property->type) {
             case 'array':
                 return $options + [
                     'allow_add' => true,
                     'allow_delete' => true,
                     'delete_empty' => true,
-                    'entry_type' => self::resolveFormType($schema->items),
-                    'entry_options' => self::resolveFormOptions($schema->items),
+                    'entry_type' => self::resolveFormType($property->items),
+                    'entry_options' => self::resolveFormOptions($property->items),
                 ];
             case 'object':
-                return $options + ['data_schema' => $schema];
+                return $options + ['data_schema' => $property];
             case 'string':
-                switch ($schema->format ?? null) {
+                switch ($property->format ?? null) {
                     case 'date-time':
                         return $options + ['input' => 'string', 'input_format' => 'c'];
                     case 'date':
@@ -116,8 +122,37 @@ class FormHelper
                     default:
                         return $options;
                 }
+            case 'number':
+                switch (true) {
+                    case static::isRangeType($property):
+                        return $options + [
+                                'attr' => [
+                                    'min' => $property->minimum ?? $property->exclusiveMinimum,
+                                    'max' => $property->maximum ?? $property->exclusiveMaximum,
+                                ],
+                            ];
+                    default:
+                        return $options;
+                }
             default:
                 return $options;
         }
     }
+
+    /**
+     * Check if the Property is from type number and has the (exclusive)minimum and (exclusive)maximum attribute
+     * @param stdClass $property
+     * @return bool
+     */
+    public static function isRangeType(stdClass $property): bool
+    {
+        return 'number' === $property->type &&
+            (property_exists($property, 'minimum')
+                || property_exists($property, 'exclusiveMinimum')
+            ) && (
+                property_exists($property, 'maximum')
+                || property_exists($property, 'exclusiveMaximum')
+            );
+    }
+
 }

--- a/tests/Form/Helper/FormHelperTest.php
+++ b/tests/Form/Helper/FormHelperTest.php
@@ -13,6 +13,7 @@ use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 use Symfony\Component\Form\Extension\Core\Type\NumberType;
+use Symfony\Component\Form\Extension\Core\Type\RangeType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Extension\Core\Type\TimeType;
 use Symfony\Component\Form\Extension\Core\Type\UrlType;
@@ -33,6 +34,10 @@ class FormHelperTest extends TestCase
         yield [(object) ['type' => 'object'], SchemaType::class];
         yield [(object) ['type' => 'integer'], IntegerType::class];
         yield [(object) ['type' => 'number'], NumberType::class];
+        yield [(object)['type' => 'number', 'minimum' => 0, 'maximum' => 100,], RangeType::class];
+        yield [(object) ['type' => 'number', 'exclusiveMinimum' => 0, 'maximum' => 100,], RangeType::class];
+        yield [(object) ['type' => 'number', 'minimum' => 0, 'exclusiveMaximum' => 100,], RangeType::class];
+        yield [(object) ['type' => 'number','exclusiveMinimum' => 0,'exclusiveMaximum' => 100,], RangeType::class];
         yield [(object) ['type' => 'boolean'], CheckboxType::class];
         yield [(object) ['type' => 'string', 'enum' => []], ChoiceType::class];
         yield [(object) ['type' => 'string', 'format' => 'date-time'], DateTimeType::class];
@@ -55,8 +60,50 @@ class FormHelperTest extends TestCase
 
     public function resolveFormOptionsDataProvider()
     {
+        yield [
+            (object)[
+                'type' => 'array',
+                'items' => (object)[
+                    'type' => 'object',
+                    'title' => 'My nested Schema 1',
+                    'description' => 'Yet another nested Schema 1',
+                    'properties' => (object)[
+                        'foo' => (object)[
+                            'title' => 'String in Nested Schema',
+                            'description' => 'Test the nested schema', 'default' => 'the default',
+                            'type' => 'string',
+                        ],
+                    ],
+                ],
+            ],
+            [
+                'allow_add' => true,
+                'allow_delete' => true,
+                'delete_empty' => true,
+                'entry_type' => SchemaType::class,
+                'entry_options' => [
+                    'label' => 'My nested Schema 1',
+                    'help' => 'Yet another nested Schema 1',
+                    'data_schema' => (object)[
+                        'type' => 'object', 'title' => 'My nested Schema 1',
+                        'description' => 'Yet another nested Schema 1',
+                        'properties' => (object)[
+                            'foo' => (object)[
+                                'title' => 'String in Nested Schema',
+                                'description' => 'Test the nested schema',
+                                'default' => 'the default', 'type' => 'string',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
         yield [(object) ['type' => 'array', 'items' => (object) ['type' => 'string', 'default' => 'foo']], ['allow_add' => true, 'allow_delete' => true, 'delete_empty' => true, 'entry_type' => TextType::class, 'entry_options' => ['empty_data' => 'foo']]];
         yield [(object) ['type' => 'object', 'title' => 'Lorem ipsum'], ['label' => 'Lorem ipsum', 'data_schema' => (object) ['type' => 'object', 'title' => 'Lorem ipsum']]];
+        yield [(object) ['type' => 'number', 'minimum' => 0, 'maximum' => 100,],['attr' => ['min' => 0, 'max' => 100,],],];
+        yield [(object) ['type' => 'number', 'exclusiveMinimum' => 0, 'maximum' => 100,],['attr' => ['min' => 0,'max' => 100,],],];
+        yield [(object) ['type' => 'number', 'minimum' => 0, 'exclusiveMaximum' => 100,],['attr' => ['min' => 0,'max' => 100,],],];
+        yield [(object) ['type' => 'number', 'exclusiveMinimum' => 0, 'exclusiveMaximum' => 100,],['attr' => ['min' => 0,'max' => 100,],],];
         yield [(object) ['type' => 'string', 'title' => 'Lorem ipsum'], ['label' => 'Lorem ipsum']];
         yield [(object) ['type' => 'string', 'description' => 'Lorem ipsum'], ['help' => 'Lorem ipsum']];
         yield [(object) ['type' => 'string', 'default' => 'foo'], ['empty_data' => 'foo']];

--- a/tests/Form/Helper/FormHelperTest.php
+++ b/tests/Form/Helper/FormHelperTest.php
@@ -53,9 +53,14 @@ class FormHelperTest extends TestCase
         yield [(object) ['type' => 'integer'], IntegerType::class];
         yield [(object) ['type' => 'number'], NumberType::class];
         yield [(object)['type' => 'number', 'minimum' => 0, 'maximum' => 100,], RangeType::class];
+        // DRAFT-07 Version Number Range
         yield [(object) ['type' => 'number', 'exclusiveMinimum' => 0, 'maximum' => 100,], RangeType::class];
         yield [(object) ['type' => 'number', 'minimum' => 0, 'exclusiveMaximum' => 100,], RangeType::class];
-        yield [(object) ['type' => 'number','exclusiveMinimum' => 0,'exclusiveMaximum' => 100,], RangeType::class];
+        yield [(object) ['type' => 'number', 'exclusiveMinimum' => 0,'exclusiveMaximum' => 100,], RangeType::class];
+        // DRAFT-04 Version Number Range
+        yield [(object) ['type' => 'number', 'minimum' => 0, 'exclusiveMinimum' => true, 'maximum' => 100,], RangeType::class];
+        yield [(object) ['type' => 'number', 'minimum' => 0, 'maximum' => 100, 'exclusiveMaximum' => true,], RangeType::class];
+        yield [(object) ['type' => 'number', 'minimum' => 0, 'exclusiveMinimum' => true, 'maximum' => 100,'exclusiveMaximum' => false,], RangeType::class];
         yield [(object) ['type' => 'boolean'], CheckboxType::class];
         yield [(object) ['type' => 'string', 'enum' => []], ChoiceType::class];
         yield [(object) ['type' => 'string', 'format' => 'date-time'], DateTimeType::class];
@@ -131,9 +136,14 @@ class FormHelperTest extends TestCase
         yield [(object) ['type' => 'array', 'items' => (object) ['type' => 'string', 'default' => 'foo']], ['allow_add' => true, 'allow_delete' => true, 'delete_empty' => true, 'entry_type' => TextType::class, 'entry_options' => ['empty_data' => 'foo']]];
         yield [(object) ['type' => 'object', 'title' => 'Lorem ipsum'], ['label' => 'Lorem ipsum', 'data_schema' => (object) ['type' => 'object', 'title' => 'Lorem ipsum']]];
         yield [(object) ['type' => 'number', 'minimum' => 0, 'maximum' => 100,],['attr' => ['min' => 0, 'max' => 100,],],];
+        // DRAFT-07 Number Range
         yield [(object) ['type' => 'number', 'exclusiveMinimum' => 0, 'maximum' => 100,],['attr' => ['min' => 0,'max' => 100,],],];
         yield [(object) ['type' => 'number', 'minimum' => 0, 'exclusiveMaximum' => 100,],['attr' => ['min' => 0,'max' => 100,],],];
         yield [(object) ['type' => 'number', 'exclusiveMinimum' => 0, 'exclusiveMaximum' => 100,],['attr' => ['min' => 0,'max' => 100,],],];
+        // DRAFT-04 Number Range
+        yield [(object) ['type' => 'number', 'minimum' => 0, 'exclusiveMinimum' => true, 'maximum' => 100,],['attr' => ['min' => 0,'max' => 100,],],];
+        yield [(object) ['type' => 'number', 'minimum' => 0, 'maximum' => 100, 'exclusiveMaximum' => true,],['attr' => ['min' => 0,'max' => 100,],],];
+        yield [(object) ['type' => 'number', 'minimum' => 0, 'exclusiveMinimum' => true, 'maximum' => 100,'exclusiveMaximum' => false,],['attr' => ['min' => 0,'max' => 100,],],];
         yield [(object) ['type' => 'string', 'title' => 'Lorem ipsum'], ['label' => 'Lorem ipsum']];
         yield [(object) ['type' => 'string', 'description' => 'Lorem ipsum'], ['help' => 'Lorem ipsum']];
         yield [(object) ['type' => 'string', 'default' => 'foo'], ['empty_data' => 'foo']];

--- a/tests/Form/Helper/FormHelperTest.php
+++ b/tests/Form/Helper/FormHelperTest.php
@@ -4,9 +4,7 @@ namespace Cyve\JsonSchemaFormBundle\Tests\Form\Helper;
 
 use Cyve\JsonSchemaFormBundle\Form\Helper\FormHelper;
 use Cyve\JsonSchemaFormBundle\Form\Type\SchemaType;
-use LogicException;
 use PHPUnit\Framework\TestCase;
-use stdClass;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
@@ -19,7 +17,6 @@ use Symfony\Component\Form\Extension\Core\Type\RangeType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Extension\Core\Type\TimeType;
 use Symfony\Component\Form\Extension\Core\Type\UrlType;
-use TypeError;
 
 /**
  * Class FormHelperTest
@@ -36,10 +33,10 @@ class FormHelperTest extends TestCase
      */
     public function testResolveFormType($property, $expected)
     {
-        if (is_a($expected, LogicException::class, true)) {
+        if (is_a($expected, \LogicException::class, true)) {
             $this->expectException($expected);
         }
-        if (is_a($expected, TypeError::class, true)) {
+        if (is_a($expected, \TypeError::class, true)) {
             $this->expectException($expected);
         }
         $formType = FormHelper::resolveFormType($property);
@@ -71,8 +68,8 @@ class FormHelperTest extends TestCase
         yield [(object) ['type' => 'string', 'format' => 'foo'], TextType::class];
         yield [(object) ['type' => 'string'], TextType::class];
         yield [(object) ['type' => 'null'], null];
-        yield [(object) ['type' => ['null', 'string']], LogicException::class];
-        yield [['type' => 'string'], TypeError::class];
+        yield [(object) ['type' => ['null', 'string']], \LogicException::class];
+        yield [['type' => 'string'], \TypeError::class];
     }
 
     /**
@@ -84,10 +81,10 @@ class FormHelperTest extends TestCase
      */
     public function testResolveFormOptions($property, $expected)
     {
-        if (is_a($expected, LogicException::class, true)) {
+        if (is_a($expected, \LogicException::class, true)) {
             $this->expectException($expected);
         }
-        if (is_a($expected, TypeError::class, true)) {
+        if (is_a($expected, \TypeError::class, true)) {
             $this->expectException($expected);
         }
         $this->assertEquals($expected, FormHelper::resolveFormOptions($property));
@@ -151,7 +148,7 @@ class FormHelperTest extends TestCase
         yield [(object) ['type' => 'string', 'format' => 'date-time'], ['input' => 'string', 'input_format' => 'c']];
         yield [(object) ['type' => 'string', 'format' => 'date'], ['input' => 'string', 'input_format' => 'Y-m-d']];
         yield [(object) ['type' => 'string', 'format' => 'time'], ['input' => 'string', 'input_format' => 'H:i:s']];
-        yield [(object) ['type' => ['string', null], 'default' => 'foo'], LogicException::class];
-        yield [['type' => ['string', null], 'default' => 'foo'], TypeError::class];
+        yield [(object) ['type' => ['string', null], 'default' => 'foo'], \LogicException::class];
+        yield [['type' => ['string', null], 'default' => 'foo'], \TypeError::class];
     }
 }

--- a/tests/Form/Helper/FormHelperTest.php
+++ b/tests/Form/Helper/FormHelperTest.php
@@ -4,7 +4,9 @@ namespace Cyve\JsonSchemaFormBundle\Tests\Form\Helper;
 
 use Cyve\JsonSchemaFormBundle\Form\Helper\FormHelper;
 use Cyve\JsonSchemaFormBundle\Form\Type\SchemaType;
+use LogicException;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
@@ -17,15 +19,31 @@ use Symfony\Component\Form\Extension\Core\Type\RangeType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\Extension\Core\Type\TimeType;
 use Symfony\Component\Form\Extension\Core\Type\UrlType;
+use TypeError;
 
+/**
+ * Class FormHelperTest
+ * @package Cyve\JsonSchemaFormBundle\Tests\Form\Helper
+ * @coversDefaultClass \Cyve\JsonSchemaFormBundle\Form\Helper\FormHelper
+ */
 class FormHelperTest extends TestCase
 {
     /**
+     * @covers ::resolveFormType
      * @dataProvider resolveFormTypeDataProvider
+     * @param mixed $property
+     * @param mixed $expected
      */
-    public function testResolveFormType($schema, $expected)
+    public function testResolveFormType($property, $expected)
     {
-        $this->assertEquals($expected, FormHelper::resolveFormType($schema));
+        if (is_a($expected, LogicException::class, true)) {
+            $this->expectException($expected);
+        }
+        if (is_a($expected, TypeError::class, true)) {
+            $this->expectException($expected);
+        }
+        $formType = FormHelper::resolveFormType($property);
+        $this->assertEquals($expected, $formType);
     }
 
     public function resolveFormTypeDataProvider()
@@ -48,14 +66,26 @@ class FormHelperTest extends TestCase
         yield [(object) ['type' => 'string', 'format' => 'foo'], TextType::class];
         yield [(object) ['type' => 'string'], TextType::class];
         yield [(object) ['type' => 'null'], null];
+        yield [(object) ['type' => ['null', 'string']], LogicException::class];
+        yield [['type' => 'string'], TypeError::class];
     }
 
     /**
+     * @covers ::resolveFormOptions
      * @dataProvider resolveFormOptionsDataProvider
+     *
+     * @param mixed $property
+     * @param mixed $expected
      */
-    public function testResolveFormOptions($schema, $expected)
+    public function testResolveFormOptions($property, $expected)
     {
-        $this->assertEquals($expected, FormHelper::resolveFormOptions($schema));
+        if (is_a($expected, LogicException::class, true)) {
+            $this->expectException($expected);
+        }
+        if (is_a($expected, TypeError::class, true)) {
+            $this->expectException($expected);
+        }
+        $this->assertEquals($expected, FormHelper::resolveFormOptions($property));
     }
 
     public function resolveFormOptionsDataProvider()
@@ -111,5 +141,7 @@ class FormHelperTest extends TestCase
         yield [(object) ['type' => 'string', 'format' => 'date-time'], ['input' => 'string', 'input_format' => 'c']];
         yield [(object) ['type' => 'string', 'format' => 'date'], ['input' => 'string', 'input_format' => 'Y-m-d']];
         yield [(object) ['type' => 'string', 'format' => 'time'], ['input' => 'string', 'input_format' => 'H:i:s']];
+        yield [(object) ['type' => ['string', null], 'default' => 'foo'], LogicException::class];
+        yield [['type' => ['string', null], 'default' => 'foo'], TypeError::class];
     }
 }


### PR DESCRIPTION
Changed the argument name of the methods 'resolveFormType' and 'resolveFormOptions' from schema to property for more clearness.

The Unit tests were expanded about a Exception test and new the implemented 'RangeType'.
